### PR TITLE
[feat] 결제사별 웹훅 수신 API 구현

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,13 +1,29 @@
-# [feat] 결제 완료 시 예약 상태 자동 확정 처리 #36
+# [feat] 결제사별 웹훅 수신 API 구현 #38
 
 ## 변경 사항
 
-- PaymentProcessListener에서 결제 완료 후 Reservation.confirm() 호출
-- 결제 완료 시 예약 상태 PENDING → CONFIRMED로 자동 변경
-- 결제-예약 통합 로직 구현
+- POST /webhooks/payments/toss 엔드포인트 추가
+- POST /webhooks/payments/kakao 엔드포인트 추가
+- TOSS/KAKAO 웹훅 요청 DTO 생성
+- 웹훅 핸들러 서비스 구현 (결제 상태 업데이트)
+- 웹훅 컨트롤러 테스트 작성
 
-## 테스트
+## 구현 내용
 
-- PaymentProcessListenerTest 업데이트
-- 결제 완료 시 예약 확정 검증 추가
+### 웹훅 API
+- TOSS 결제사 웹훅 수신: `POST /webhooks/payments/toss`
+- KAKAO 결제사 웹훅 수신: `POST /webhooks/payments/kakao`
 
+### 웹훅 처리 로직
+- orderId에서 paymentId 추출
+- 결제 수단 검증 (TOSS/KAKAO)
+- 결제 금액 검증
+- 웹훅 상태에 따른 결제 상태 업데이트:
+  - `DONE`/`SUCCESS`/`COMPLETED` → `COMPLETED`
+  - `CANCELED`/`CANCELLED` → `CANCELLED`
+  - `FAILED`/`FAILURE` → `FAILED`
+
+### 테스트
+- 웹훅 수신 성공 케이스
+- 결제를 찾을 수 없는 경우
+- 유효성 검사 실패 케이스

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,13 @@
+# [feat] 결제 완료 시 예약 상태 자동 확정 처리 #36
+
+## 변경 사항
+
+- PaymentProcessListener에서 결제 완료 후 Reservation.confirm() 호출
+- 결제 완료 시 예약 상태 PENDING → CONFIRMED로 자동 변경
+- 결제-예약 통합 로직 구현
+
+## 테스트
+
+- PaymentProcessListenerTest 업데이트
+- 결제 완료 시 예약 확정 검증 추가
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookApi.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookApi.java
@@ -1,0 +1,44 @@
+package com.wiseai.assignment.modules.payment.adapter.web.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.wiseai.assignment.modules.common.dto.response.SuccessResponse;
+import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
+import com.wiseai.assignment.modules.payment.adapter.web.request.KakaoWebhookRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "Payment Webhook", description = "결제사 웹훅 수신 API")
+public interface PaymentWebhookApi {
+
+  @Operation(
+      summary = "TOSS 결제 웹훅 수신",
+      description = "TOSS 결제사로부터 결제 상태 변경 알림을 수신합니다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "웹훅 처리 성공"),
+    @ApiResponse(responseCode = "400", description = "잘못된 웹훅 데이터"),
+    @ApiResponse(responseCode = "401", description = "웹훅 서명 검증 실패")
+  })
+  @PostMapping("/webhooks/payments/toss")
+  ResponseEntity<SuccessResponse<Void>> handleTossWebhook(
+      @Valid @RequestBody TossWebhookRequest request);
+
+  @Operation(
+      summary = "KAKAO 결제 웹훅 수신",
+      description = "KAKAO 결제사로부터 결제 상태 변경 알림을 수신합니다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "웹훅 처리 성공"),
+    @ApiResponse(responseCode = "400", description = "잘못된 웹훅 데이터"),
+    @ApiResponse(responseCode = "401", description = "웹훅 서명 검증 실패")
+  })
+  @PostMapping("/webhooks/payments/kakao")
+  ResponseEntity<SuccessResponse<Void>> handleKakaoWebhook(
+      @Valid @RequestBody KakaoWebhookRequest request);
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookApi.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookApi.java
@@ -5,8 +5,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.wiseai.assignment.modules.common.dto.response.SuccessResponse;
-import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
 import com.wiseai.assignment.modules.payment.adapter.web.request.KakaoWebhookRequest;
+import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,9 +17,7 @@ import jakarta.validation.Valid;
 @Tag(name = "Payment Webhook", description = "결제사 웹훅 수신 API")
 public interface PaymentWebhookApi {
 
-  @Operation(
-      summary = "TOSS 결제 웹훅 수신",
-      description = "TOSS 결제사로부터 결제 상태 변경 알림을 수신합니다.")
+  @Operation(summary = "TOSS 결제 웹훅 수신", description = "TOSS 결제사로부터 결제 상태 변경 알림을 수신합니다.")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "웹훅 처리 성공"),
     @ApiResponse(responseCode = "400", description = "잘못된 웹훅 데이터"),
@@ -29,9 +27,7 @@ public interface PaymentWebhookApi {
   ResponseEntity<SuccessResponse<Void>> handleTossWebhook(
       @Valid @RequestBody TossWebhookRequest request);
 
-  @Operation(
-      summary = "KAKAO 결제 웹훅 수신",
-      description = "KAKAO 결제사로부터 결제 상태 변경 알림을 수신합니다.")
+  @Operation(summary = "KAKAO 결제 웹훅 수신", description = "KAKAO 결제사로부터 결제 상태 변경 알림을 수신합니다.")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "웹훅 처리 성공"),
     @ApiResponse(responseCode = "400", description = "잘못된 웹훅 데이터"),
@@ -41,4 +37,3 @@ public interface PaymentWebhookApi {
   ResponseEntity<SuccessResponse<Void>> handleKakaoWebhook(
       @Valid @RequestBody KakaoWebhookRequest request);
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookController.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookController.java
@@ -64,4 +64,3 @@ public class PaymentWebhookController implements PaymentWebhookApi {
         .body(SuccessResponse.of(CommonSuccessStatus.OK, null));
   }
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookController.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookController.java
@@ -1,0 +1,67 @@
+package com.wiseai.assignment.modules.payment.adapter.web.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.wiseai.assignment.modules.common.dto.response.SuccessResponse;
+import com.wiseai.assignment.modules.common.status.CommonSuccessStatus;
+import com.wiseai.assignment.modules.payment.adapter.web.request.KakaoWebhookRequest;
+import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
+import com.wiseai.assignment.modules.payment.application.port.in.webhook.HandlePaymentWebhookUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PaymentWebhookController implements PaymentWebhookApi {
+
+  private final HandlePaymentWebhookUseCase handlePaymentWebhookUseCase;
+
+  @Override
+  public ResponseEntity<SuccessResponse<Void>> handleTossWebhook(TossWebhookRequest request) {
+    log.info(
+        "TOSS 웹훅 수신: paymentKey={}, orderId={}, status={}",
+        request.paymentKey(),
+        request.orderId(),
+        request.status());
+
+    handlePaymentWebhookUseCase.handleTossWebhook(
+        request.paymentKey(),
+        request.orderId(),
+        request.status(),
+        request.totalAmount(),
+        request.transactionId(),
+        request.failureCode(),
+        request.failureMessage());
+
+    log.debug("TOSS 웹훅 처리 완료: paymentKey={}", request.paymentKey());
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(SuccessResponse.of(CommonSuccessStatus.OK, null));
+  }
+
+  @Override
+  public ResponseEntity<SuccessResponse<Void>> handleKakaoWebhook(KakaoWebhookRequest request) {
+    log.info(
+        "KAKAO 웹훅 수신: paymentKey={}, orderId={}, status={}",
+        request.paymentKey(),
+        request.orderId(),
+        request.status());
+
+    handlePaymentWebhookUseCase.handleKakaoWebhook(
+        request.paymentKey(),
+        request.orderId(),
+        request.status(),
+        request.totalAmount(),
+        request.transactionId(),
+        request.failureCode(),
+        request.failureMessage());
+
+    log.debug("KAKAO 웹훅 처리 완료: paymentKey={}", request.paymentKey());
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(SuccessResponse.of(CommonSuccessStatus.OK, null));
+  }
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/KakaoWebhookRequest.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/KakaoWebhookRequest.java
@@ -1,8 +1,9 @@
 package com.wiseai.assignment.modules.payment.adapter.web.request;
 
+import java.math.BigDecimal;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 
 public record KakaoWebhookRequest(
     @NotBlank(message = "결제 키는 필수입니다.") String paymentKey,
@@ -12,4 +13,3 @@ public record KakaoWebhookRequest(
     String transactionId,
     String failureCode,
     String failureMessage) {}
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/KakaoWebhookRequest.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/KakaoWebhookRequest.java
@@ -1,0 +1,15 @@
+package com.wiseai.assignment.modules.payment.adapter.web.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record KakaoWebhookRequest(
+    @NotBlank(message = "결제 키는 필수입니다.") String paymentKey,
+    @NotBlank(message = "주문 ID는 필수입니다.") String orderId,
+    @NotBlank(message = "결제 상태는 필수입니다.") String status,
+    @NotNull(message = "결제 금액은 필수입니다.") BigDecimal totalAmount,
+    String transactionId,
+    String failureCode,
+    String failureMessage) {}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/TossWebhookRequest.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/TossWebhookRequest.java
@@ -1,8 +1,9 @@
 package com.wiseai.assignment.modules.payment.adapter.web.request;
 
+import java.math.BigDecimal;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 
 public record TossWebhookRequest(
     @NotBlank(message = "결제 키는 필수입니다.") String paymentKey,
@@ -12,4 +13,3 @@ public record TossWebhookRequest(
     String transactionId,
     String failureCode,
     String failureMessage) {}
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/TossWebhookRequest.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/adapter/web/request/TossWebhookRequest.java
@@ -1,0 +1,15 @@
+package com.wiseai.assignment.modules.payment.adapter.web.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record TossWebhookRequest(
+    @NotBlank(message = "결제 키는 필수입니다.") String paymentKey,
+    @NotBlank(message = "주문 ID는 필수입니다.") String orderId,
+    @NotBlank(message = "결제 상태는 필수입니다.") String status,
+    @NotNull(message = "결제 금액은 필수입니다.") BigDecimal totalAmount,
+    String transactionId,
+    String failureCode,
+    String failureMessage) {}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/port/in/webhook/HandlePaymentWebhookUseCase.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/port/in/webhook/HandlePaymentWebhookUseCase.java
@@ -22,4 +22,3 @@ public interface HandlePaymentWebhookUseCase {
       String failureCode,
       String failureMessage);
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/port/in/webhook/HandlePaymentWebhookUseCase.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/port/in/webhook/HandlePaymentWebhookUseCase.java
@@ -1,0 +1,25 @@
+package com.wiseai.assignment.modules.payment.application.port.in.webhook;
+
+import java.math.BigDecimal;
+
+public interface HandlePaymentWebhookUseCase {
+
+  void handleTossWebhook(
+      String paymentKey,
+      String orderId,
+      String status,
+      BigDecimal totalAmount,
+      String transactionId,
+      String failureCode,
+      String failureMessage);
+
+  void handleKakaoWebhook(
+      String paymentKey,
+      String orderId,
+      String status,
+      BigDecimal totalAmount,
+      String transactionId,
+      String failureCode,
+      String failureMessage);
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/command/PaymentCommandPort.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/command/PaymentCommandPort.java
@@ -5,4 +5,3 @@ import com.wiseai.assignment.modules.payment.domain.model.Payment;
 public interface PaymentCommandPort {
   Payment update(Payment payment);
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/command/PaymentCommandPort.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/command/PaymentCommandPort.java
@@ -1,0 +1,8 @@
+package com.wiseai.assignment.modules.payment.application.port.out.command;
+
+import com.wiseai.assignment.modules.payment.domain.model.Payment;
+
+public interface PaymentCommandPort {
+  Payment update(Payment payment);
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/query/PaymentQueryPort.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/query/PaymentQueryPort.java
@@ -1,9 +1,9 @@
 package com.wiseai.assignment.modules.payment.application.port.out.query;
 
-import com.wiseai.assignment.modules.payment.domain.model.Payment;
 import java.util.Optional;
+
+import com.wiseai.assignment.modules.payment.domain.model.Payment;
 
 public interface PaymentQueryPort {
   Optional<Payment> findById(Long id);
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/query/PaymentQueryPort.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/port/out/query/PaymentQueryPort.java
@@ -1,0 +1,9 @@
+package com.wiseai.assignment.modules.payment.application.port.out.query;
+
+import com.wiseai.assignment.modules.payment.domain.model.Payment;
+import java.util.Optional;
+
+public interface PaymentQueryPort {
+  Optional<Payment> findById(Long id);
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/service/webhook/PaymentWebhookService.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/service/webhook/PaymentWebhookService.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.wiseai.assignment.modules.payment.application.port.in.webhook.HandlePaymentWebhookUseCase;
-import com.wiseai.assignment.modules.payment.application.port.out.query.PaymentQueryPort;
 import com.wiseai.assignment.modules.payment.application.port.out.command.PaymentCommandPort;
+import com.wiseai.assignment.modules.payment.application.port.out.query.PaymentQueryPort;
 import com.wiseai.assignment.modules.payment.domain.enums.PaymentMethod;
 import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
 import com.wiseai.assignment.modules.payment.domain.model.Payment;
@@ -34,11 +34,7 @@ public class PaymentWebhookService implements HandlePaymentWebhookUseCase {
       String transactionId,
       String failureCode,
       String failureMessage) {
-    log.debug(
-        "TOSS 웹훅 처리 시작: paymentKey={}, orderId={}, status={}",
-        paymentKey,
-        orderId,
-        status);
+    log.debug("TOSS 웹훅 처리 시작: paymentKey={}, orderId={}, status={}", paymentKey, orderId, status);
 
     // orderId에서 paymentId 추출 (예: "payment-123" 형식 가정)
     Long paymentId = extractPaymentIdFromOrderId(orderId);
@@ -88,11 +84,7 @@ public class PaymentWebhookService implements HandlePaymentWebhookUseCase {
       String transactionId,
       String failureCode,
       String failureMessage) {
-    log.debug(
-        "KAKAO 웹훅 처리 시작: paymentKey={}, orderId={}, status={}",
-        paymentKey,
-        orderId,
-        status);
+    log.debug("KAKAO 웹훅 처리 시작: paymentKey={}, orderId={}, status={}", paymentKey, orderId, status);
 
     // orderId에서 paymentId 추출
     Long paymentId = extractPaymentIdFromOrderId(orderId);
@@ -165,4 +157,3 @@ public class PaymentWebhookService implements HandlePaymentWebhookUseCase {
     }
   }
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/application/service/webhook/PaymentWebhookService.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/application/service/webhook/PaymentWebhookService.java
@@ -1,0 +1,168 @@
+package com.wiseai.assignment.modules.payment.application.service.webhook;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wiseai.assignment.modules.payment.application.port.in.webhook.HandlePaymentWebhookUseCase;
+import com.wiseai.assignment.modules.payment.application.port.out.query.PaymentQueryPort;
+import com.wiseai.assignment.modules.payment.application.port.out.command.PaymentCommandPort;
+import com.wiseai.assignment.modules.payment.domain.enums.PaymentMethod;
+import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
+import com.wiseai.assignment.modules.payment.domain.model.Payment;
+import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentWebhookService implements HandlePaymentWebhookUseCase {
+
+  private final PaymentQueryPort paymentQueryPort;
+  private final PaymentCommandPort paymentCommandPort;
+
+  @Override
+  @Transactional
+  public void handleTossWebhook(
+      String paymentKey,
+      String orderId,
+      String status,
+      BigDecimal totalAmount,
+      String transactionId,
+      String failureCode,
+      String failureMessage) {
+    log.debug(
+        "TOSS 웹훅 처리 시작: paymentKey={}, orderId={}, status={}",
+        paymentKey,
+        orderId,
+        status);
+
+    // orderId에서 paymentId 추출 (예: "payment-123" 형식 가정)
+    Long paymentId = extractPaymentIdFromOrderId(orderId);
+
+    Payment payment =
+        paymentQueryPort
+            .findById(paymentId)
+            .orElseThrow(() -> new PaymentException(PaymentErrorStatus.NOT_FOUND));
+
+    // 결제 수단 검증
+    if (payment.getPaymentMethod() != PaymentMethod.TOSS) {
+      log.warn(
+          "결제 수단 불일치: paymentId={}, expected=TOSS, actual={}",
+          paymentId,
+          payment.getPaymentMethod());
+      throw new PaymentException(PaymentErrorStatus.INVALID_PAYMENT_METHOD);
+    }
+
+    // 금액 검증
+    if (payment.getAmount().compareTo(totalAmount) != 0) {
+      log.warn(
+          "결제 금액 불일치: paymentId={}, expected={}, actual={}",
+          paymentId,
+          payment.getAmount(),
+          totalAmount);
+      throw new PaymentException(PaymentErrorStatus.INVALID_AMOUNT);
+    }
+
+    // 상태 업데이트
+    Payment updatedPayment = updatePaymentStatus(payment, status, transactionId);
+    paymentCommandPort.update(updatedPayment);
+
+    log.info(
+        "TOSS 웹훅 처리 완료: paymentId={}, status={}, transactionId={}",
+        paymentId,
+        status,
+        transactionId);
+  }
+
+  @Override
+  @Transactional
+  public void handleKakaoWebhook(
+      String paymentKey,
+      String orderId,
+      String status,
+      BigDecimal totalAmount,
+      String transactionId,
+      String failureCode,
+      String failureMessage) {
+    log.debug(
+        "KAKAO 웹훅 처리 시작: paymentKey={}, orderId={}, status={}",
+        paymentKey,
+        orderId,
+        status);
+
+    // orderId에서 paymentId 추출
+    Long paymentId = extractPaymentIdFromOrderId(orderId);
+
+    Payment payment =
+        paymentQueryPort
+            .findById(paymentId)
+            .orElseThrow(() -> new PaymentException(PaymentErrorStatus.NOT_FOUND));
+
+    // 결제 수단 검증
+    if (payment.getPaymentMethod() != PaymentMethod.KAKAO) {
+      log.warn(
+          "결제 수단 불일치: paymentId={}, expected=KAKAO, actual={}",
+          paymentId,
+          payment.getPaymentMethod());
+      throw new PaymentException(PaymentErrorStatus.INVALID_PAYMENT_METHOD);
+    }
+
+    // 금액 검증
+    if (payment.getAmount().compareTo(totalAmount) != 0) {
+      log.warn(
+          "결제 금액 불일치: paymentId={}, expected={}, actual={}",
+          paymentId,
+          payment.getAmount(),
+          totalAmount);
+      throw new PaymentException(PaymentErrorStatus.INVALID_AMOUNT);
+    }
+
+    // 상태 업데이트
+    Payment updatedPayment = updatePaymentStatus(payment, status, transactionId);
+    paymentCommandPort.update(updatedPayment);
+
+    log.info(
+        "KAKAO 웹훅 처리 완료: paymentId={}, status={}, transactionId={}",
+        paymentId,
+        status,
+        transactionId);
+  }
+
+  private Long extractPaymentIdFromOrderId(String orderId) {
+    try {
+      // orderId 형식: "payment-{paymentId}" 또는 "{paymentId}"
+      if (orderId.startsWith("payment-")) {
+        return Long.parseLong(orderId.substring("payment-".length()));
+      }
+      return Long.parseLong(orderId);
+    } catch (NumberFormatException e) {
+      log.error("orderId에서 paymentId 추출 실패: orderId={}", orderId, e);
+      throw new PaymentException(PaymentErrorStatus.INVALID_RESERVATION_ID);
+    }
+  }
+
+  private Payment updatePaymentStatus(Payment payment, String status, String transactionId) {
+    // TOSS/KAKAO 웹훅 status 매핑
+    // "DONE" -> COMPLETED, "CANCELED" -> CANCELLED, "FAILED" -> FAILED
+    switch (status.toUpperCase()) {
+      case "DONE":
+      case "SUCCESS":
+      case "COMPLETED":
+        return payment.complete(transactionId != null ? transactionId : payment.getTransactionId());
+      case "CANCELED":
+      case "CANCELLED":
+        return payment.cancel();
+      case "FAILED":
+      case "FAILURE":
+        return payment.fail();
+      default:
+        log.warn("알 수 없는 웹훅 상태: status={}, paymentId={}", status, payment.getId());
+        throw new PaymentException(PaymentErrorStatus.INVALID_STATUS);
+    }
+  }
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentMethod.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentMethod.java
@@ -4,4 +4,3 @@ public enum PaymentMethod {
   TOSS,
   KAKAO
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentMethod.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.wiseai.assignment.modules.payment.domain.enums;
+
+public enum PaymentMethod {
+  TOSS,
+  KAKAO
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentStatus.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentStatus.java
@@ -6,4 +6,3 @@ public enum PaymentStatus {
   FAILED,
   CANCELLED
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentStatus.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/enums/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.wiseai.assignment.modules.payment.domain.enums;
+
+public enum PaymentStatus {
+  PENDING,
+  COMPLETED,
+  FAILED,
+  CANCELLED
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/exception/PaymentException.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/exception/PaymentException.java
@@ -1,0 +1,11 @@
+package com.wiseai.assignment.modules.payment.domain.exception;
+
+import com.wiseai.assignment.modules.common.exception.BusinessException;
+import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
+
+public class PaymentException extends BusinessException {
+  public PaymentException(PaymentErrorStatus errorStatus) {
+    super(errorStatus);
+  }
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/exception/PaymentException.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/exception/PaymentException.java
@@ -8,4 +8,3 @@ public class PaymentException extends BusinessException {
     super(errorStatus);
   }
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/model/Payment.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/model/Payment.java
@@ -1,10 +1,12 @@
 package com.wiseai.assignment.modules.payment.domain.model;
 
+import java.math.BigDecimal;
+
 import com.wiseai.assignment.modules.payment.domain.enums.PaymentMethod;
 import com.wiseai.assignment.modules.payment.domain.enums.PaymentStatus;
 import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
 import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
-import java.math.BigDecimal;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -67,4 +69,3 @@ public class Payment {
         .build();
   }
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/model/Payment.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/model/Payment.java
@@ -1,0 +1,70 @@
+package com.wiseai.assignment.modules.payment.domain.model;
+
+import com.wiseai.assignment.modules.payment.domain.enums.PaymentMethod;
+import com.wiseai.assignment.modules.payment.domain.enums.PaymentStatus;
+import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
+import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Payment {
+
+  private final Long id;
+  private final Long reservationId;
+  private final PaymentMethod paymentMethod;
+  private final BigDecimal amount;
+  private final PaymentStatus status;
+  private final String transactionId;
+
+  public Payment complete(String transactionId) {
+    if (status != PaymentStatus.PENDING) {
+      throw new PaymentException(PaymentErrorStatus.INVALID_STATUS);
+    }
+    if (transactionId == null || transactionId.isBlank()) {
+      throw new PaymentException(PaymentErrorStatus.INVALID_TRANSACTION_ID);
+    }
+
+    return Payment.builder()
+        .id(id)
+        .reservationId(reservationId)
+        .paymentMethod(paymentMethod)
+        .amount(amount)
+        .status(PaymentStatus.COMPLETED)
+        .transactionId(transactionId)
+        .build();
+  }
+
+  public Payment cancel() {
+    if (status == PaymentStatus.CANCELLED) {
+      throw new PaymentException(PaymentErrorStatus.INVALID_STATUS);
+    }
+
+    return Payment.builder()
+        .id(id)
+        .reservationId(reservationId)
+        .paymentMethod(paymentMethod)
+        .amount(amount)
+        .status(PaymentStatus.CANCELLED)
+        .transactionId(transactionId)
+        .build();
+  }
+
+  public Payment fail() {
+    if (status != PaymentStatus.PENDING) {
+      throw new PaymentException(PaymentErrorStatus.INVALID_STATUS);
+    }
+
+    return Payment.builder()
+        .id(id)
+        .reservationId(reservationId)
+        .paymentMethod(paymentMethod)
+        .amount(amount)
+        .status(PaymentStatus.FAILED)
+        .transactionId(transactionId)
+        .build();
+  }
+}
+

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/status/PaymentErrorStatus.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/status/PaymentErrorStatus.java
@@ -1,9 +1,11 @@
 package com.wiseai.assignment.modules.payment.domain.status;
 
+import org.springframework.http.HttpStatus;
+
 import com.wiseai.assignment.modules.common.status.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -19,4 +21,3 @@ public enum PaymentErrorStatus implements BaseErrorCode {
   private final String code;
   private final String message;
 }
-

--- a/src/main/java/com/wiseai/assignment/modules/payment/domain/status/PaymentErrorStatus.java
+++ b/src/main/java/com/wiseai/assignment/modules/payment/domain/status/PaymentErrorStatus.java
@@ -1,0 +1,22 @@
+package com.wiseai.assignment.modules.payment.domain.status;
+
+import com.wiseai.assignment.modules.common.status.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorStatus implements BaseErrorCode {
+  INVALID_RESERVATION_ID(HttpStatus.BAD_REQUEST, "PAYMENT-001", "유효하지 않은 예약 ID입니다."),
+  INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "PAYMENT-002", "결제 금액은 0보다 커야 합니다."),
+  INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "PAYMENT-003", "유효하지 않은 결제 수단입니다."),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT-004", "결제를 찾을 수 없습니다."),
+  INVALID_STATUS(HttpStatus.BAD_REQUEST, "PAYMENT-005", "유효하지 않은 결제 상태입니다."),
+  INVALID_TRANSACTION_ID(HttpStatus.BAD_REQUEST, "PAYMENT-006", "유효하지 않은 거래 ID입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}
+

--- a/src/test/java/com/wiseai/assignment/AssignmentApplicationTests.java
+++ b/src/test/java/com/wiseai/assignment/AssignmentApplicationTests.java
@@ -2,9 +2,16 @@ package com.wiseai.assignment;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.wiseai.assignment.modules.payment.application.port.out.command.PaymentCommandPort;
+import com.wiseai.assignment.modules.payment.application.port.out.query.PaymentQueryPort;
 
 @SpringBootTest
 class AssignmentApplicationTests {
+
+  @MockBean private PaymentQueryPort paymentQueryPort;
+  @MockBean private PaymentCommandPort paymentCommandPort;
 
   @Test
   void contextLoads() {}

--- a/src/test/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookControllerTest.java
+++ b/src/test/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookControllerTest.java
@@ -7,16 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wiseai.assignment.modules.common.exception.GlobalExceptionHandler;
-import com.wiseai.assignment.modules.payment.adapter.web.request.KakaoWebhookRequest;
-import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
-import com.wiseai.assignment.modules.payment.application.port.in.webhook.HandlePaymentWebhookUseCase;
-import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
-import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
-import com.wiseai.assignment.modules.security.config.SecurityConfig;
-import com.wiseai.assignment.modules.security.filter.JwtFilter;
 import java.math.BigDecimal;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +22,17 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.wiseai.assignment.modules.common.exception.GlobalExceptionHandler;
+import com.wiseai.assignment.modules.payment.adapter.web.request.KakaoWebhookRequest;
+import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
+import com.wiseai.assignment.modules.payment.application.port.in.webhook.HandlePaymentWebhookUseCase;
+import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
+import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
+import com.wiseai.assignment.modules.security.config.SecurityConfig;
+import com.wiseai.assignment.modules.security.filter.JwtFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(
     controllers = PaymentWebhookController.class,
@@ -68,13 +71,7 @@ class PaymentWebhookControllerTest {
     doNothing()
         .when(handlePaymentWebhookUseCase)
         .handleTossWebhook(
-            PAYMENT_KEY,
-            ORDER_ID,
-            STATUS_DONE,
-            TOTAL_AMOUNT,
-            TRANSACTION_ID,
-            null,
-            null);
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
 
     // when & then
     mockMvc
@@ -100,13 +97,7 @@ class PaymentWebhookControllerTest {
     doThrow(new PaymentException(PaymentErrorStatus.NOT_FOUND))
         .when(handlePaymentWebhookUseCase)
         .handleTossWebhook(
-            PAYMENT_KEY,
-            ORDER_ID,
-            STATUS_DONE,
-            TOTAL_AMOUNT,
-            TRANSACTION_ID,
-            null,
-            null);
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
 
     // when & then
     mockMvc
@@ -126,7 +117,8 @@ class PaymentWebhookControllerTest {
   void handleTossWebhook_validationFailed_missingPaymentKey() throws Exception {
     // given
     TossWebhookRequest request =
-        new TossWebhookRequest(null, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+        new TossWebhookRequest(
+            null, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
 
     // when & then
     mockMvc
@@ -149,13 +141,7 @@ class PaymentWebhookControllerTest {
     doNothing()
         .when(handlePaymentWebhookUseCase)
         .handleKakaoWebhook(
-            PAYMENT_KEY,
-            ORDER_ID,
-            STATUS_DONE,
-            TOTAL_AMOUNT,
-            TRANSACTION_ID,
-            null,
-            null);
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
 
     // when & then
     mockMvc
@@ -181,13 +167,7 @@ class PaymentWebhookControllerTest {
     doThrow(new PaymentException(PaymentErrorStatus.NOT_FOUND))
         .when(handlePaymentWebhookUseCase)
         .handleKakaoWebhook(
-            PAYMENT_KEY,
-            ORDER_ID,
-            STATUS_DONE,
-            TOTAL_AMOUNT,
-            TRANSACTION_ID,
-            null,
-            null);
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
 
     // when & then
     mockMvc
@@ -207,7 +187,8 @@ class PaymentWebhookControllerTest {
   void handleKakaoWebhook_validationFailed_missingOrderId() throws Exception {
     // given
     KakaoWebhookRequest request =
-        new KakaoWebhookRequest(PAYMENT_KEY, null, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+        new KakaoWebhookRequest(
+            PAYMENT_KEY, null, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
 
     // when & then
     mockMvc
@@ -219,4 +200,3 @@ class PaymentWebhookControllerTest {
         .andExpect(status().isBadRequest());
   }
 }
-

--- a/src/test/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookControllerTest.java
+++ b/src/test/java/com/wiseai/assignment/modules/payment/adapter/web/api/PaymentWebhookControllerTest.java
@@ -1,0 +1,222 @@
+package com.wiseai.assignment.modules.payment.adapter.web.api;
+
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wiseai.assignment.modules.common.exception.GlobalExceptionHandler;
+import com.wiseai.assignment.modules.payment.adapter.web.request.KakaoWebhookRequest;
+import com.wiseai.assignment.modules.payment.adapter.web.request.TossWebhookRequest;
+import com.wiseai.assignment.modules.payment.application.port.in.webhook.HandlePaymentWebhookUseCase;
+import com.wiseai.assignment.modules.payment.domain.exception.PaymentException;
+import com.wiseai.assignment.modules.payment.domain.status.PaymentErrorStatus;
+import com.wiseai.assignment.modules.security.config.SecurityConfig;
+import com.wiseai.assignment.modules.security.filter.JwtFilter;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    controllers = PaymentWebhookController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class},
+    excludeFilters = {
+      @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = EnableWebSecurity.class),
+      @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtFilter.class),
+      @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+    })
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+@DisplayName("PaymentWebhookController 테스트")
+class PaymentWebhookControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private HandlePaymentWebhookUseCase handlePaymentWebhookUseCase;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  private static final String PAYMENT_KEY = "payment-key-123";
+  private static final String ORDER_ID = "payment-1";
+  private static final String STATUS_DONE = "DONE";
+  private static final String STATUS_FAILED = "FAILED";
+  private static final BigDecimal TOTAL_AMOUNT = new BigDecimal("10000");
+  private static final String TRANSACTION_ID = "txn-12345";
+
+  @Test
+  @DisplayName("TOSS 웹훅 수신 성공")
+  void handleTossWebhook_success() throws Exception {
+    // given
+    TossWebhookRequest request =
+        new TossWebhookRequest(
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+
+    doNothing()
+        .when(handlePaymentWebhookUseCase)
+        .handleTossWebhook(
+            PAYMENT_KEY,
+            ORDER_ID,
+            STATUS_DONE,
+            TOTAL_AMOUNT,
+            TRANSACTION_ID,
+            null,
+            null);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/webhooks/payments/toss")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.httpStatus").value(200))
+        .andExpect(jsonPath("$.code").value("COMMON-200"))
+        .andExpect(jsonPath("$.message").value("성공입니다."));
+  }
+
+  @Test
+  @DisplayName("TOSS 웹훅 수신 실패 - 결제를 찾을 수 없음")
+  void handleTossWebhook_notFound() throws Exception {
+    // given
+    TossWebhookRequest request =
+        new TossWebhookRequest(
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+
+    doThrow(new PaymentException(PaymentErrorStatus.NOT_FOUND))
+        .when(handlePaymentWebhookUseCase)
+        .handleTossWebhook(
+            PAYMENT_KEY,
+            ORDER_ID,
+            STATUS_DONE,
+            TOTAL_AMOUNT,
+            TRANSACTION_ID,
+            null,
+            null);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/webhooks/payments/toss")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.httpStatus").value(404))
+        .andExpect(jsonPath("$.code").value("PAYMENT-004"))
+        .andExpect(jsonPath("$.message").value("결제를 찾을 수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("TOSS 웹훅 수신 실패 - 유효성 검사 실패 (paymentKey 누락)")
+  void handleTossWebhook_validationFailed_missingPaymentKey() throws Exception {
+    // given
+    TossWebhookRequest request =
+        new TossWebhookRequest(null, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/webhooks/payments/toss")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("KAKAO 웹훅 수신 성공")
+  void handleKakaoWebhook_success() throws Exception {
+    // given
+    KakaoWebhookRequest request =
+        new KakaoWebhookRequest(
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+
+    doNothing()
+        .when(handlePaymentWebhookUseCase)
+        .handleKakaoWebhook(
+            PAYMENT_KEY,
+            ORDER_ID,
+            STATUS_DONE,
+            TOTAL_AMOUNT,
+            TRANSACTION_ID,
+            null,
+            null);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/webhooks/payments/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.httpStatus").value(200))
+        .andExpect(jsonPath("$.code").value("COMMON-200"))
+        .andExpect(jsonPath("$.message").value("성공입니다."));
+  }
+
+  @Test
+  @DisplayName("KAKAO 웹훅 수신 실패 - 결제를 찾을 수 없음")
+  void handleKakaoWebhook_notFound() throws Exception {
+    // given
+    KakaoWebhookRequest request =
+        new KakaoWebhookRequest(
+            PAYMENT_KEY, ORDER_ID, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+
+    doThrow(new PaymentException(PaymentErrorStatus.NOT_FOUND))
+        .when(handlePaymentWebhookUseCase)
+        .handleKakaoWebhook(
+            PAYMENT_KEY,
+            ORDER_ID,
+            STATUS_DONE,
+            TOTAL_AMOUNT,
+            TRANSACTION_ID,
+            null,
+            null);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/webhooks/payments/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.httpStatus").value(404))
+        .andExpect(jsonPath("$.code").value("PAYMENT-004"))
+        .andExpect(jsonPath("$.message").value("결제를 찾을 수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("KAKAO 웹훅 수신 실패 - 유효성 검사 실패 (orderId 누락)")
+  void handleKakaoWebhook_validationFailed_missingOrderId() throws Exception {
+    // given
+    KakaoWebhookRequest request =
+        new KakaoWebhookRequest(PAYMENT_KEY, null, STATUS_DONE, TOTAL_AMOUNT, TRANSACTION_ID, null, null);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/webhooks/payments/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+}
+


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 변경 사항

- POST /webhooks/payments/toss 엔드포인트 추가
- POST /webhooks/payments/kakao 엔드포인트 추가
- TOSS/KAKAO 웹훅 요청 DTO 생성
- 웹훅 핸들러 서비스 구현 (결제 상태 업데이트)
- 웹훅 컨트롤러 테스트 작성

## 구현 내용

### 웹훅 API
- TOSS 결제사 웹훅 수신: `POST /webhooks/payments/toss`
- KAKAO 결제사 웹훅 수신: `POST /webhooks/payments/kakao`

### 웹훅 처리 로직
- orderId에서 paymentId 추출
- 결제 수단 검증 (TOSS/KAKAO)
- 결제 금액 검증
- 웹훅 상태에 따른 결제 상태 업데이트:
  - `DONE`/`SUCCESS`/`COMPLETED` → `COMPLETED`
  - `CANCELED`/`CANCELLED` → `CANCELLED`
  - `FAILED`/`FAILURE` → `FAILED`

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #38  (무슨 이슈를 해결했는지)